### PR TITLE
Add option to display radio buttons as power strip

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -20,6 +20,11 @@
                             "placeholder": "unique group name",
                             "description": "The name of the group, that is initially used as the display name."
                         },
+                        "displayAsPowerStrip": {
+                            "title": "Display As Power Strip",
+                            "type": "boolean",
+                            "description": "Create the radio buttons as a power strip instead of a group of switches. Provides a more compact UI in the Apple Home app."
+                        },
                         "switches": {
                             "type": "array",
                             "items": {

--- a/src/lib/controllers/group-controller.ts
+++ b/src/lib/controllers/group-controller.ts
@@ -28,11 +28,12 @@ export class GroupController {
         });
 
         // Creates all switches of the controller
+        const accessoryType = (groupConfiguration.displayAs == "Outlet") ? "Outlet" : "Switch"
         for (let switchConfiguration of groupConfiguration.switches) {
-            platform.logger.info(`[${groupConfiguration.name}] Adding switch ${switchConfiguration.name}`);
+            platform.logger.info(`[${groupConfiguration.name}] Adding ${accessoryType.toLowerCase()} ${switchConfiguration.name}`);
 
             // Creates the service and characteristic
-            const switchService = accessory.useService(Homebridge.Services.Switch, switchConfiguration.name, `${switchConfiguration.name}-switch`);
+            const switchService = accessory.useService(Homebridge.Services[accessoryType], switchConfiguration.name, `${switchConfiguration.name}-switch`);
             const onCharacteristic = switchService.useCharacteristic<boolean>(Homebridge.Characteristics.On);
             this.onCharacteristics.push({
                 configuration: switchConfiguration,

--- a/src/lib/controllers/group-controller.ts
+++ b/src/lib/controllers/group-controller.ts
@@ -28,7 +28,7 @@ export class GroupController {
         });
 
         // Creates all switches of the controller
-        const accessoryType = (groupConfiguration.displayAs == "Outlet") ? "Outlet" : "Switch"
+        const accessoryType = (groupConfiguration.displayAsPowerStrip) ? "Outlet" : "Switch"
         for (let switchConfiguration of groupConfiguration.switches) {
             platform.logger.info(`[${groupConfiguration.name}] Adding ${accessoryType.toLowerCase()} ${switchConfiguration.name}`);
 


### PR DESCRIPTION
Thanks for a useful plugin! I've added an option (displayAsPowerStrip) to use outlet accessories instead of switches since this displays much more compactly in the Apple Home app.

<img width="507" alt="Switches" src="https://user-images.githubusercontent.com/11694945/153296085-73f22798-f9a9-4a8d-93f3-133fcc16dcf0.png">

<img width="506" alt="Power Strip" src="https://user-images.githubusercontent.com/11694945/153296182-fb8e14d1-2496-4967-bf8a-aee656363391.png">

