### PR TITLE
Fix Switch Names Not Carrying Over to HomeKit

### DIFF
--- a/src/lib/controllers/group-controller.ts
+++ b/src/lib/controllers/group-controller.ts
@@ -38,6 +38,9 @@ export class GroupController {
             } else {
                 switchService = accessory.useService(Homebridge.Services.Switch, switchConfiguration.name, `${switchConfiguration.name}-switch`);
             }
+
+            switchService.useCharacteristic(Homebridge.Characteristics.Name, switchConfiguration.name);
+
             const onCharacteristic = switchService.useCharacteristic<boolean>(Homebridge.Characteristics.On);
             this.onCharacteristics.push({
                 configuration: switchConfiguration,


### PR DESCRIPTION
Issue #10 raised a concern regarding switch names not being transferred to HomeKit, resulting in all switches appearing with the same name as the Group Name in HomeKit. To resolve this, I have implemented a fix that ensures switch names set within the plug-in settings are now correctly propagated to HomeKit. With this update, each switch will now display its unique name in HomeKit, making it easier for users to differentiate between them. This improvement enhances the overall user experience and helps create a more intuitive and organized HomeKit environment.